### PR TITLE
Updating a reference to build tools

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="7.0.3" />
     <PackageReference Include="ReportGenerator" Version="5.1.24" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
-    <PackageDownload Include="coveralls.net" version="[4.0.1]" />
+    <PackageReference Include="GitVersion.Tool" Version="5.12.0" ExcludeAssets="all"/>
+    <PackageReference Include="coveralls.net" Version="4.0.1" ExcludeAssets="all"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
According to dependabot/dependabot-core#2920 `PackageDownload` will not be tracked by Dependabot. Changing the references to `PackageReference` so that the bot will track and update them.