### PR TITLE
Migrating tests to Shouldly

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Vortice.D3DCompiler" Version="3.6.2" />
     <PackageVersion Include="Vortice.Direct3D11" Version="3.6.2" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageVersion Include="Shouldly" Version="4.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />

--- a/test/Demo.Engine.Core.UTs/Components/Keyboard/KeyboardCharCacheTests.cs
+++ b/test/Demo.Engine.Core.UTs/Components/Keyboard/KeyboardCharCacheTests.cs
@@ -4,7 +4,7 @@
 using Demo.Engine.Core.Components.Keyboard;
 using Demo.Engine.Core.Components.Keyboard.Internal;
 using Demo.Engine.Core.Interfaces.Components;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace Demo.Engine.Core.UTs.Components.Keyboard;
@@ -40,7 +40,7 @@ public class KeyboardCharCacheTests
         var result = _charResponse.ReadCache();
 
         // Assert
-        result.Should().Be("ala ma kota");
+        result.ShouldBe("ala ma kota");
     }
 
     [Fact]
@@ -53,8 +53,8 @@ public class KeyboardCharCacheTests
         var result1 = _charResponse.ReadCache();
         var result2 = _charResponse.ReadCache();
 
-        result1.Should().Be("abc");
-        result2.Should().BeEmpty();
+        result1.ShouldBe("abc");
+        result2.ShouldBeEmpty();
     }
 
     [Fact]
@@ -67,9 +67,9 @@ public class KeyboardCharCacheTests
         _keyboardCache.Char('b');
         _keyboardCache.Char('c');
 
-        _charResponse.ReadCache().Should().Be("abc");
-        charResponse1.ReadCache().Should().Be("abc");
-        charResponse2.ReadCache().Should().Be("abc");
+        _charResponse.ReadCache().ShouldBe("abc");
+        charResponse1.ReadCache().ShouldBe("abc");
+        charResponse2.ReadCache().ShouldBe("abc");
     }
 
     [Fact]
@@ -89,12 +89,12 @@ public class KeyboardCharCacheTests
         var charResponse2Read2 = charResponse2.ReadCache();
         var charResponse3Read2 = _charResponse.ReadCache();
 
-        charResponse1Read1.Should().Be("a");
-        charResponse2Read1.Should().Be("ab");
-        charResponse3Read1.Should().Be("abc");
+        charResponse1Read1.ShouldBe("a");
+        charResponse2Read1.ShouldBe("ab");
+        charResponse3Read1.ShouldBe("abc");
 
-        charResponse1Read2.Should().Be("bc");
-        charResponse2Read2.Should().Be("c");
-        charResponse3Read2.Should().BeEmpty();
+        charResponse1Read2.ShouldBe("bc");
+        charResponse2Read2.ShouldBe("c");
+        charResponse3Read2.ShouldBeEmpty();
     }
 }

--- a/test/Demo.Engine.Core.UTs/Components/Keyboard/KeyboardHandleTests.cs
+++ b/test/Demo.Engine.Core.UTs/Components/Keyboard/KeyboardHandleTests.cs
@@ -4,8 +4,8 @@
 using Demo.Engine.Core.Components.Keyboard;
 using Demo.Engine.Core.Interfaces.Components;
 using Demo.Engine.Core.Platform;
-using FluentAssertions;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace Demo.Engine.Core.UTs.Components.Keyboard;
@@ -19,11 +19,11 @@ public class KeyboardHandleTests
     {
         _mockKeyboardCache = Substitute.For<IKeyboardCache>();
         _keyboardCache = Enumerable.Repeat(false, 256).ToArray().AsMemory();
-        _mockKeyboardCache.KeysPressed.Returns(_keyboardCache);
+        _ = _mockKeyboardCache.KeysPressed.Returns(_keyboardCache);
     }
 
-    private KeyboardHandle CreateKeyboardHandle() =>
-        new KeyboardHandle(_mockKeyboardCache);
+    private KeyboardHandle CreateKeyboardHandle()
+        => new(_mockKeyboardCache);
 
     [Fact]
     public void GetKeyPressed_Only_One_Pressed()
@@ -38,7 +38,7 @@ public class KeyboardHandleTests
         foreach (var key in Enum.GetValues(typeof(VirtualKeys)).Cast<VirtualKeys>())
         {
             var result = keyboardHandle.GetKeyPressed(key);
-            result.Should().Be(key == TESTKEY, $"{key} is {result}");
+            result.ShouldBe(key == TESTKEY, $"{key} is {result}");
         }
 
         // Assert
@@ -65,7 +65,7 @@ public class KeyboardHandleTests
         foreach (var key in Enum.GetValues(typeof(VirtualKeys)).Cast<VirtualKeys>())
         {
             var result = keyboardHandle.GetKeyPressed(key);
-            result.Should().Be(testKeys.Contains(key), $"{key} is {result}");
+            result.ShouldBe(testKeys.Contains(key), $"{key} is {result}");
         }
 
         // Assert

--- a/test/Demo.Engine.Core.UTs/Demo.Engine.Core.UTs.csproj
+++ b/test/Demo.Engine.Core.UTs/Demo.Engine.Core.UTs.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp">

--- a/test/Demo.Engine.Core.UTs/Services/MainLoopServiceTests.cs
+++ b/test/Demo.Engine.Core.UTs/Services/MainLoopServiceTests.cs
@@ -10,10 +10,10 @@ using Demo.Engine.Core.Interfaces.Platform;
 using Demo.Engine.Core.Interfaces.Rendering;
 using Demo.Engine.Core.Requests.Keyboard;
 using Demo.Engine.Core.Services;
-using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.Hosting;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace Demo.Engine.Core.UTs.Services;
@@ -37,7 +37,7 @@ public class MainLoopServiceTests
     }
 
     private MainLoopService CreateService()
-        => new MainLoopService(
+        => new(
             _mockMediator,
             _mockHostApplicationLifetime,
             _mockOSMessageHandler,
@@ -60,7 +60,7 @@ public class MainLoopServiceTests
             cancellationToken);
 
         // Assert
-        func.Should().ThrowAsync<ArgumentNullException>();
+        _ = func.ShouldThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class MainLoopServiceTests
             cancellationToken);
 
         // Assert
-        func.Should().ThrowAsync<ArgumentNullException>();
+        _ = func.ShouldThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -98,14 +98,14 @@ public class MainLoopServiceTests
         var keyboardCache = new KeyboardCharCache(keybaorCacheSub);
         var keyboardHandle = new KeyboardHandle(keybaorCacheSub);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardCharCacheRequest>(),
                 Arg.Any<CancellationToken>())
             .Returns(
                 keyboardCache);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardHandleRequest>(),
                 Arg.Any<CancellationToken>())
@@ -113,11 +113,11 @@ public class MainLoopServiceTests
                 keyboardHandle);
 
         var renderingControlMock = Substitute.For<IRenderingControl>();
-        _mockRenderingEngine.Control.Returns(renderingControlMock);
+        _ = _mockRenderingEngine.Control.Returns(renderingControlMock);
 
-        _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
+        _ = _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
 
-        _mockHostApplicationLifetime.ApplicationStopping.Returns(new CancellationToken());
+        _ = _mockHostApplicationLifetime.ApplicationStopping.Returns(new CancellationToken());
 
         // Act
         var sw = Stopwatch.StartNew();
@@ -129,7 +129,7 @@ public class MainLoopServiceTests
 
         // Assert
         // We let it have a bit of a leeway
-        sw.Elapsed.TotalSeconds.Should().BeInRange(
+        sw.Elapsed.TotalSeconds.ShouldBeInRange(
             TimeSpan.FromSeconds(4.9).TotalSeconds,
             TimeSpan.FromSeconds(5.9).TotalSeconds);
     }
@@ -157,14 +157,14 @@ public class MainLoopServiceTests
         var keyboardCache = new KeyboardCharCache(keybaorCacheSub);
         var keyboardHandle = new KeyboardHandle(keybaorCacheSub);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardCharCacheRequest>(),
                 Arg.Any<CancellationToken>())
             .Returns(
                 keyboardCache);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardHandleRequest>(),
                 Arg.Any<CancellationToken>())
@@ -172,11 +172,11 @@ public class MainLoopServiceTests
                 keyboardHandle);
 
         var renderingControlMock = Substitute.For<IRenderingControl>();
-        _mockRenderingEngine.Control.Returns(renderingControlMock);
+        _ = _mockRenderingEngine.Control.Returns(renderingControlMock);
 
-        _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
+        _ = _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
 
-        _mockHostApplicationLifetime.ApplicationStopping.Returns(new CancellationToken());
+        _ = _mockHostApplicationLifetime.ApplicationStopping.Returns(new CancellationToken());
 
         // Act
         await service.RunAsync(
@@ -185,7 +185,7 @@ public class MainLoopServiceTests
             cts.Token);
 
         // Assert
-        iUpdate.Should().Be(6);
+        iUpdate.ShouldBe(6);
     }
 
     [Fact]
@@ -213,14 +213,14 @@ public class MainLoopServiceTests
         var keyboardCache = new KeyboardCharCache(keybaorCacheSub);
         var keyboardHandle = new KeyboardHandle(keybaorCacheSub);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardCharCacheRequest>(),
                 Arg.Any<CancellationToken>())
             .Returns(
                 keyboardCache);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardHandleRequest>(),
                 Arg.Any<CancellationToken>())
@@ -228,11 +228,11 @@ public class MainLoopServiceTests
                 keyboardHandle);
 
         var renderingControlMock = Substitute.For<IRenderingControl>();
-        _mockRenderingEngine.Control.Returns(renderingControlMock);
+        _ = _mockRenderingEngine.Control.Returns(renderingControlMock);
 
-        _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
+        _ = _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
 
-        _mockHostApplicationLifetime.ApplicationStopping.Returns(appLifetimeCTS.Token);
+        _ = _mockHostApplicationLifetime.ApplicationStopping.Returns(appLifetimeCTS.Token);
 
         // Act
         await service.RunAsync(
@@ -241,7 +241,7 @@ public class MainLoopServiceTests
             cts.Token);
 
         // Assert
-        iUpdate.Should().Be(6);
+        iUpdate.ShouldBe(6);
     }
 
     [Fact]
@@ -272,14 +272,14 @@ public class MainLoopServiceTests
         var keyboardCache = new KeyboardCharCache(keybaorCacheSub);
         var keyboardHandle = new KeyboardHandle(keybaorCacheSub);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardCharCacheRequest>(),
                 Arg.Any<CancellationToken>())
             .Returns(
                 keyboardCache);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardHandleRequest>(),
                 Arg.Any<CancellationToken>())
@@ -287,11 +287,11 @@ public class MainLoopServiceTests
                 keyboardHandle);
 
         var renderingControlMock = Substitute.For<IRenderingControl>();
-        _mockRenderingEngine.Control.Returns(renderingControlMock);
+        _ = _mockRenderingEngine.Control.Returns(renderingControlMock);
 
-        _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
+        _ = _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
 
-        _mockHostApplicationLifetime.ApplicationStopping.Returns(appLifetimeCTS.Token);
+        _ = _mockHostApplicationLifetime.ApplicationStopping.Returns(appLifetimeCTS.Token);
 
         // Act
         await service.RunAsync(
@@ -300,8 +300,8 @@ public class MainLoopServiceTests
             cts.Token);
 
         // Assert
-        iUpdate.Should().BeGreaterThan(0);
-        iRender.Should().BeGreaterThan(0);
+        iUpdate.ShouldBeGreaterThan(0);
+        iRender.ShouldBeGreaterThan(0);
     }
 
     [Fact]
@@ -326,14 +326,14 @@ public class MainLoopServiceTests
         var keyboardCache = new KeyboardCharCache(keybaorCacheSub);
         var keyboardHandle = new KeyboardHandle(keybaorCacheSub);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardCharCacheRequest>(),
                 Arg.Any<CancellationToken>())
             .Returns(
                 keyboardCache);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardHandleRequest>(),
                 Arg.Any<CancellationToken>())
@@ -341,11 +341,11 @@ public class MainLoopServiceTests
                 keyboardHandle);
 
         var renderingControlMock = Substitute.For<IRenderingControl>();
-        _mockRenderingEngine.Control.Returns(renderingControlMock);
+        _ = _mockRenderingEngine.Control.Returns(renderingControlMock);
 
-        _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(_ => iUpdate <= 5);
+        _ = _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(_ => iUpdate <= 5);
 
-        _mockHostApplicationLifetime.ApplicationStopping.Returns(appLifetimeCTS.Token);
+        _ = _mockHostApplicationLifetime.ApplicationStopping.Returns(appLifetimeCTS.Token);
 
         // Act
         await service.RunAsync(
@@ -354,7 +354,7 @@ public class MainLoopServiceTests
             cts.Token);
 
         // Assert
-        iUpdate.Should().Be(6);
+        iUpdate.ShouldBe(6);
     }
 
     [Fact]
@@ -371,7 +371,7 @@ public class MainLoopServiceTests
 
         Task UpdateCallback(KeyboardHandle _, KeyboardCharCache __)
         {
-            service.IsRunning.Should().BeTrue();
+            service.IsRunning.ShouldBeTrue();
             return Task.CompletedTask;
         }
 
@@ -379,14 +379,14 @@ public class MainLoopServiceTests
         var keyboardCache = new KeyboardCharCache(keybaorCacheSub);
         var keyboardHandle = new KeyboardHandle(keybaorCacheSub);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardCharCacheRequest>(),
                 Arg.Any<CancellationToken>())
             .Returns(
                 keyboardCache);
 
-        _mockMediator
+        _ = _mockMediator
             .Send(
                 Arg.Any<KeyboardHandleRequest>(),
                 Arg.Any<CancellationToken>())
@@ -394,20 +394,20 @@ public class MainLoopServiceTests
                 keyboardHandle);
 
         var renderingControlMock = Substitute.For<IRenderingControl>();
-        _mockRenderingEngine.Control.Returns(renderingControlMock);
+        _ = _mockRenderingEngine.Control.Returns(renderingControlMock);
 
-        _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
+        _ = _mockOSMessageHandler.DoEvents(renderingControlMock).Returns(true);
 
-        _mockHostApplicationLifetime.ApplicationStopping.Returns(appLifetimeCTS.Token);
+        _ = _mockHostApplicationLifetime.ApplicationStopping.Returns(appLifetimeCTS.Token);
 
         // Act
-        service.IsRunning.Should().BeFalse();
+        service.IsRunning.ShouldBeFalse();
         await service.RunAsync(
             UpdateCallback,
             RenderCallback,
             cts.Token);
 
         // Assert
-        service.IsRunning.Should().BeFalse();
+        service.IsRunning.ShouldBeFalse();
     }
 }

--- a/test/Demo.Tools.Common.UTs/Collections/CircularQueueTests.cs
+++ b/test/Demo.Tools.Common.UTs/Collections/CircularQueueTests.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Demo.Tools.Common.Collections;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace Demo.Tools.Common.UTs.Collections;
@@ -15,12 +15,12 @@ public class CircularQueueTests
     {
         var circQueue = new CircularQueue<int>(2);
         circQueue.Enqueue(123);
-        circQueue.Count.Should().Be(1);
+        circQueue.Count.ShouldBe(1);
 
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(123);
-        buffer[1].Should().Be(0);
+        buffer[0].ShouldBe(123);
+        buffer[1].ShouldBe(0);
     }
 
     [Fact]
@@ -29,12 +29,12 @@ public class CircularQueueTests
         var circQueue = new CircularQueue<int>(2);
         circQueue.Enqueue(123);
         circQueue.Enqueue(456);
-        circQueue.Count.Should().Be(2);
+        circQueue.Count.ShouldBe(2);
 
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(123);
-        buffer[1].Should().Be(456);
+        buffer[0].ShouldBe(123);
+        buffer[1].ShouldBe(456);
     }
 
     [Fact]
@@ -44,12 +44,12 @@ public class CircularQueueTests
         circQueue.Enqueue(123);
         circQueue.Enqueue(456);
         circQueue.Enqueue(789);
-        circQueue.Count.Should().Be(2);
+        circQueue.Count.ShouldBe(2);
 
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(456);
-        buffer[1].Should().Be(789);
+        buffer[0].ShouldBe(456);
+        buffer[1].ShouldBe(789);
     }
 
     [Fact]
@@ -61,12 +61,12 @@ public class CircularQueueTests
         circQueue.Enqueue(789);
         var dequeued = circQueue.Dequeue();
 
-        circQueue.Count.Should().Be(1);
-        dequeued.Should().Be(456);
+        circQueue.Count.ShouldBe(1);
+        dequeued.ShouldBe(456);
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(789);
-        buffer[1].Should().Be(0);
+        buffer[0].ShouldBe(789);
+        buffer[1].ShouldBe(0);
     }
 
     [Fact]
@@ -79,12 +79,12 @@ public class CircularQueueTests
         var dequeued = circQueue.Dequeue();
         circQueue.Enqueue(159);
 
-        circQueue.Count.Should().Be(2);
-        dequeued.Should().Be(456);
+        circQueue.Count.ShouldBe(2);
+        dequeued.ShouldBe(456);
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(789);
-        buffer[1].Should().Be(159);
+        buffer[0].ShouldBe(789);
+        buffer[1].ShouldBe(159);
     }
 
     [Fact]
@@ -93,13 +93,13 @@ public class CircularQueueTests
         var circQueue = new CircularQueue<int>(2);
 
         Action act = () => circQueue.Dequeue();
-        act.Should().Throw<InvalidOperationException>();
+        _ = act.ShouldThrow<InvalidOperationException>();
 
-        circQueue.Count.Should().Be(0);
+        circQueue.Count.ShouldBe(0);
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(0);
-        buffer[1].Should().Be(0);
+        buffer[0].ShouldBe(0);
+        buffer[1].ShouldBe(0);
     }
 
     [Fact]
@@ -108,14 +108,14 @@ public class CircularQueueTests
         var circQueue = new CircularQueue<int>(2);
         var peeked = circQueue.TryDequeue(out var result);
 
-        peeked.Should().BeFalse();
-        result.Should().Be(default);
+        peeked.ShouldBeFalse();
+        result.ShouldBe(default);
 
-        circQueue.Count.Should().Be(0);
+        circQueue.Count.ShouldBe(0);
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(0);
-        buffer[1].Should().Be(0);
+        buffer[0].ShouldBe(0);
+        buffer[1].ShouldBe(0);
     }
 
     [Fact]
@@ -127,12 +127,12 @@ public class CircularQueueTests
         circQueue.Enqueue(789);
         var peaked = circQueue.Peek();
 
-        circQueue.Count.Should().Be(2);
-        peaked.Should().Be(456);
+        circQueue.Count.ShouldBe(2);
+        peaked.ShouldBe(456);
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(456);
-        buffer[1].Should().Be(789);
+        buffer[0].ShouldBe(456);
+        buffer[1].ShouldBe(789);
     }
 
     [Fact]
@@ -145,14 +145,14 @@ public class CircularQueueTests
         var peaked1 = circQueue.Peek();
         var peaked2 = circQueue.Peek();
 
-        circQueue.Count.Should().Be(2);
-        peaked1.Should().Be(456);
-        peaked2.Should().Be(456);
+        circQueue.Count.ShouldBe(2);
+        peaked1.ShouldBe(456);
+        peaked2.ShouldBe(456);
 
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(456);
-        buffer[1].Should().Be(789);
+        buffer[0].ShouldBe(456);
+        buffer[1].ShouldBe(789);
     }
 
     [Fact]
@@ -163,7 +163,7 @@ public class CircularQueueTests
     public void Constructor_negative_capacity()
     {
         Action circQueue = () => new CircularQueue<int>(-2);
-        circQueue.Should().Throw<InvalidOperationException>();
+        _ = circQueue.ShouldThrow<InvalidOperationException>();
     }
 
     [Fact]
@@ -172,13 +172,13 @@ public class CircularQueueTests
         var circQueue = new CircularQueue<int>(2);
         Action peek = () => circQueue.Peek();
 
-        peek.Should().Throw<InvalidOperationException>();
+        _ = peek.ShouldThrow<InvalidOperationException>();
 
-        circQueue.Count.Should().Be(0);
+        circQueue.Count.ShouldBe(0);
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(0);
-        buffer[1].Should().Be(0);
+        buffer[0].ShouldBe(0);
+        buffer[1].ShouldBe(0);
     }
 
     [Fact]
@@ -187,13 +187,13 @@ public class CircularQueueTests
         var circQueue = new CircularQueue<int>(2);
         var peeked = circQueue.TryPeek(out var result);
 
-        peeked.Should().BeFalse();
-        result.Should().Be(default);
+        peeked.ShouldBeFalse();
+        result.ShouldBe(default);
 
-        circQueue.Count.Should().Be(0);
+        circQueue.Count.ShouldBe(0);
         var buffer = new int[2];
         circQueue.CopyTo(buffer, 0);
-        buffer[0].Should().Be(0);
-        buffer[1].Should().Be(0);
+        buffer[0].ShouldBe(0);
+        buffer[1].ShouldBe(0);
     }
 }

--- a/test/Demo.Tools.Common.UTs/Demo.Tools.Common.UTs.csproj
+++ b/test/Demo.Tools.Common.UTs/Demo.Tools.Common.UTs.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/test/Demo.Tools.Common.UTs/Extensions/DependencyInjection/ScopedDIExtensionsTests.cs
+++ b/test/Demo.Tools.Common.UTs/Extensions/DependencyInjection/ScopedDIExtensionsTests.cs
@@ -2,8 +2,8 @@
 // Distributed under MIT license. See LICENSE file in the root for more information.
 
 using Demo.Tools.Common.Extensions.DependencyInjection;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
 using Xunit;
 
 namespace Demo.Tools.Common.UTs.Extensions.DependencyInjection;
@@ -16,12 +16,12 @@ public class ScopedDIExtensionsTests
         // Arrange
         IServiceCollection services = new ServiceCollection();
         var counter = new Counter();
-        services.AddSingleton(_ => counter);
+        _ = services.AddSingleton(_ => counter);
 
         // Act
-        services.AddScoped<Bar>();
-        services.AddScoped<Foo1, Bar>();
-        services.AddScoped<Foo2, Bar>();
+        _ = services.AddScoped<Bar>();
+        _ = services.AddScoped<Foo1, Bar>();
+        _ = services.AddScoped<Foo2, Bar>();
 
         //Assert
         var serviceProvider = services.BuildServiceProvider();
@@ -29,11 +29,11 @@ public class ScopedDIExtensionsTests
         var foo2 = serviceProvider.GetRequiredService<Foo2>();
         var bar = serviceProvider.GetRequiredService<Bar>();
 
-        foo1.Should().NotBeSameAs(bar);
-        foo2.Should().NotBeSameAs(bar);
-        foo2.Should().NotBeSameAs(foo1);
+        foo1.ShouldNotBeSameAs(bar);
+        foo2.ShouldNotBeSameAs(bar);
+        foo2.ShouldNotBeSameAs(foo1);
 
-        counter.ConstructedNo.Should().Be(3);
+        counter.ConstructedNo.ShouldBe(3);
     }
 
     [Fact]
@@ -42,9 +42,9 @@ public class ScopedDIExtensionsTests
         // Arrange
         IServiceCollection services = new ServiceCollection();
         var counter = new Counter();
-        services.AddSingleton(_ => counter);
+        _ = services.AddSingleton(_ => counter);
         // Act
-        services.AddScoped<Foo1, Foo2, Bar>();
+        _ = services.AddScoped<Foo1, Foo2, Bar>();
 
         // Assert
         var serviceProvider = services.BuildServiceProvider();
@@ -52,9 +52,9 @@ public class ScopedDIExtensionsTests
         var foo2 = serviceProvider.GetRequiredService<Foo2>();
         var bar = serviceProvider.GetRequiredService<Bar>();
 
-        foo1.Should().BeSameAs(bar);
-        foo2.Should().BeSameAs(bar);
-        counter.ConstructedNo.Should().Be(1);
+        foo1.ShouldBeSameAs(bar);
+        foo2.ShouldBeSameAs(bar);
+        counter.ConstructedNo.ShouldBe(1);
     }
 
     public interface Foo1

--- a/test/Demo.Tools.Common.UTs/Extensions/LockSlim/ReaderWriterLockSlimExtensionsTests.cs
+++ b/test/Demo.Tools.Common.UTs/Extensions/LockSlim/ReaderWriterLockSlimExtensionsTests.cs
@@ -3,7 +3,7 @@
 
 using System.Text;
 using Demo.Tools.Common.Extensions.LockSlim;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace Demo.Tools.Common.UTs.Extensions.LockSlim;
@@ -30,30 +30,30 @@ public class ReaderWriterLockSlimExtensionsTests
         var sb = new StringBuilder();
         var threadJobs = new List<ThreadJob>
             {
-                new ThreadJob(T1, () => lockSlim.TryEnterWriteLock(TimeSpan.FromSeconds(20))),
-                new ThreadJob(T1, () =>
+                new(T1, () => lockSlim.TryEnterWriteLock(TimeSpan.FromSeconds(20))),
+                new(T1, () =>
                 {
-                    sb.Append("T1 start");
+                    _ = sb.Append("T1 start");
                     Thread.Sleep(5);
                 }),
-                new ThreadJob(T2, () => lockSlim.TryEnterWriteLock(TimeSpan.FromSeconds(20))),
-                new ThreadJob(T1, () =>
+                new(T2, () => lockSlim.TryEnterWriteLock(TimeSpan.FromSeconds(20))),
+                new(T1, () =>
                 {
-                    sb.Append("T1 end");
+                    _ = sb.Append("T1 end");
                     Thread.Sleep(5);
                 }),
-                new ThreadJob(T1, () => lockSlim.ExitWriteLock()),
-                new ThreadJob(T2, () =>
+                new(T1, lockSlim.ExitWriteLock),
+                new(T2, () =>
                 {
-                    sb.Append("T2 start");
+                    _ = sb.Append("T2 start");
                     Thread.Sleep(5);
                 }),
-                new ThreadJob(T2, () =>
+                new(T2, () =>
                 {
-                    sb.Append("T2 end");
+                    _ = sb.Append("T2 end");
                     Thread.Sleep(5);
                 }),
-                new ThreadJob(T2, () => lockSlim.ExitWriteLock())
+                new(T2, lockSlim.ExitWriteLock)
             };
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
@@ -67,8 +67,8 @@ public class ReaderWriterLockSlimExtensionsTests
                 tw2.Start()
         });
 
-        sb.ToString().Should().Contain("T1 startT1 end");
-        sb.ToString().Should().Contain("T2 startT2 end");
+        sb.ToString().ShouldContain("T1 startT1 end");
+        sb.ToString().ShouldContain("T2 startT2 end");
     }
 
     [Fact]
@@ -89,32 +89,32 @@ public class ReaderWriterLockSlimExtensionsTests
 
         var threadJobs = new List<ThreadJob>
             {
-                new ThreadJob(T1, () => lockSlim.EnterWriteLockBlock(() =>
+                new(T1, () => lockSlim.EnterWriteLockBlock(() =>
                 {
-                    sb.Append("T1 start");
+                    _ = sb.Append("T1 start");
                     while (!cts.IsCancellationRequested && !t1FinishedWriting)
                     {
                         Thread.Sleep(5);
                         t1Started = true;
                     }
-                    sb.Append("T1 end");
+                    _ = sb.Append("T1 end");
                 })),
-                new ThreadJob(T2, () =>
+                new(T2, () =>
                 {
                     while (!cts.IsCancellationRequested && !t1Started)
                     {
                         Thread.Sleep(5);
                     }
-                    sb.Append("T2 attempt");
+                    _ = sb.Append("T2 attempt");
                     t2Started = true;
-                    lockSlim.EnterWriteLockBlock(() =>
+                    _ = lockSlim.EnterWriteLockBlock(() =>
                     {
-                        sb.Append("T2 start");
+                        _ = sb.Append("T2 start");
                         Thread.Sleep(5);
-                        sb.Append("T2 end");
+                        _ = sb.Append("T2 end");
                     });
                 }),
-                new ThreadJob(T3, () =>
+                new(T3, () =>
                 {
                     while (!t1Started || !t2Started)
                     {
@@ -134,7 +134,7 @@ public class ReaderWriterLockSlimExtensionsTests
             tw2.Start(),
             tw3.Start());
 
-        sb.ToString().Should().Be(
+        sb.ToString().ShouldBe(
             "T1 start" +
             "T2 attempt" +
             "T1 end" +


### PR DESCRIPTION
Removing FluentAssertions and moving to Shouldly, since FluentAssertions now requires a commercial license for 8.0

(cherry picked from commit c7d02cc6b5509b9704d019509c874db085ad2542)