### PR TITLE
Fixed `DisposedException` when calling `mainLoopLifetime.Cancel`

### DIFF
--- a/src/Demo.Engine.Core/Features/StaThread/StaThreadService.cs
+++ b/src/Demo.Engine.Core/Features/StaThread/StaThreadService.cs
@@ -58,18 +58,16 @@ internal sealed class StaThreadService
                         osMessageHandler: osMessageHandler,
                         cancellationToken: cts.Token));
 
-                tcs.SetResult();
+                FinishRunning(tcs);
             }
             catch (OperationCanceledException)
             {
-                tcs.SetResult();
+                FinishRunning(tcs);
             }
             catch (Exception ex)
             {
-                tcs.SetException(ex);
+                FinishRunning(tcs, ex);
             }
-            IsRunning = false;
-            _mainLoopLifetime.Cancel();
         });
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -85,6 +83,26 @@ internal sealed class StaThreadService
         thread.Start();
 
         return tcs.Task;
+
+        void FinishRunning(
+            TaskCompletionSource tcs,
+            Exception? exception = null)
+        {
+            /* This should be called BEFORE tcs.SetResult/tcs.SetException!
+             * Otherwise _mainLoopLifetime.Cancel() gets called after the returned tcs.Task completes,
+             * leading to dispoes exception on mainLoopLifetime, that's already disposed upstream! */
+            IsRunning = false;
+            _mainLoopLifetime.Cancel();
+
+            if (exception is null)
+            {
+                tcs.SetResult();
+            }
+            else
+            {
+                tcs.SetException(exception);
+            }
+        }
     }
 
     private async Task STAThread(

--- a/src/Demo.Engine.Core/Services/MainLoopLifetime.cs
+++ b/src/Demo.Engine.Core/Services/MainLoopLifetime.cs
@@ -23,7 +23,7 @@ internal sealed class MainLoopLifetime
 
     private void Dispose(bool disposing)
     {
-        if (Interlocked.Exchange(ref _disposedValue, 1) != 0)
+        if (Interlocked.CompareExchange(ref _disposedValue, 1, 0) > 0)
         {
             return;
         }


### PR DESCRIPTION
The `mainLoopLifetime.Cancel()` in `StaThreadService` was called after `TaskCompletionSource.SetResult()`. That task ending was leading to `MainLoopLifetime` being already disposed before the `Cancel()` was called, causing `DisposedException` if the completion and disposal happened fast enough. Moving the call to `mainLoopLifetime.Cancel()` before `tcs.SetResult`/`tcs.SetException` ensures this will not happen.

Fixes #501