### PR TITLE
More logging fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -307,6 +307,9 @@ dotnet_diagnostic.CA2216.severity = warning
 dotnet_diagnostic.CA2215.severity = warning
 dotnet_diagnostic.CA1816.severity = warning
 dotnet_diagnostic.CA1873.severity = warning
+dotnet_code_quality.CA1873.max_log_level = Critical
+dotnet_diagnostic.CA2254.severity = warning
+dotnet_diagnostic.CA1727.severity = warning
 
 
 # Verify

--- a/benchmark/Demo.Engine.Benchmarks/TypedValueErrorBenchmarks.cs
+++ b/benchmark/Demo.Engine.Benchmarks/TypedValueErrorBenchmarks.cs
@@ -83,7 +83,7 @@ public class TypedValueErrorBenchmarks
         => ValueResult.LogAndReturnFailure<int, string, string>(
             _logger,
             (
-                (logger, s1, s2) => logger.LogInformation("Logging out of range error for {paramName}, {errorMessage}", s1, s2),
+                (logger, s1, s2) => logger.LogInformation("Logging out of range error for {ParamName}, {ErrorMessage}", s1, s2),
                 PARAM_NAME,
                 ERROR_MESSAGE
             ),

--- a/src/Demo.Engine.Core/Services/LoggingExtensions.cs
+++ b/src/Demo.Engine.Core/Services/LoggingExtensions.cs
@@ -10,7 +10,7 @@ namespace Demo.Engine.Core.Services;
 internal static partial class LoggingExtensions
 {
     private const string SERVICE_IS_STARTING = "{ServiceName} starting! v{Version}";
-    private const string SERVICE_IS_WORKING = "{serviceName} working! v{Version}";
+    private const string SERVICE_IS_WORKING = "{ServiceName} working! v{Version}";
     private const string SERVICE_IS_STOPPING = "{ServiceName} stopping!";
     private const string SERVICE_FAILED_WITH_ERROR = "{ServiceName} failed with error! {ErrorMessage}";
 

--- a/src/Demo.Engine.Core/Services/LoopJob.cs
+++ b/src/Demo.Engine.Core/Services/LoopJob.cs
@@ -60,7 +60,10 @@ internal sealed class LoopJob
             var str = keyboardCharCache?.ReadCache();
             if (!string.IsNullOrEmpty(str))
             {
+#pragma warning disable CA2254 // Template should be a static expression
+                // this is to print for debug reasons, not a genuine log fie
                 _logger.LogInformation(str);
+#pragma warning restore CA2254 // Template should be a static expression
             }
         }
         if (keyboardHandle.GetKeyPressed(VirtualKeys.Escape))

--- a/src/Demo.Engine.Platform.DirectX12/Cube.cs
+++ b/src/Demo.Engine.Platform.DirectX12/Cube.cs
@@ -7,6 +7,7 @@ using Demo.Engine.Core.Interfaces;
 using Demo.Engine.Core.Interfaces.Rendering;
 using Demo.Engine.Platform.DirectX12.Buffers;
 using Demo.Engine.Platform.DirectX12.Shaders;
+using Demo.Tools.Common.Logging;
 using Microsoft.Extensions.Logging;
 using SharpGen.Runtime;
 using Vortice.Direct3D;
@@ -374,7 +375,7 @@ internal sealed class Cube
     {
         if (!_disposedValue)
         {
-            _logger.LogTrace("Disposing Cube!");
+            using var _ = _logger.LogScopeDisposal();
             if (disposing)
             {
                 // TODO: dispose managed state (managed objects)
@@ -389,8 +390,6 @@ internal sealed class Cube
             // TODO: free unmanaged resources (unmanaged objects) and override finalizer
             // TODO: set large fields to null
             _disposedValue = true;
-
-            _logger.LogTrace("Disposed Cube!");
         }
     }
 

--- a/src/Demo.Engine.Platform.DirectX12/D3D12RenderingEngine.cs
+++ b/src/Demo.Engine.Platform.DirectX12/D3D12RenderingEngine.cs
@@ -111,7 +111,7 @@ internal sealed class D3D12RenderingEngine : ID3D12RenderingEngine
 
         if (descriptorHeaps.IsError)
         {
-            _logger.LogError("Failed to create descriptor heaps: {errorMessage}",
+            _logger.LogFailedToCreateDescriptorHeaps(
                 descriptorHeaps.Error.Message);
 
             throw new InvalidOperationException(
@@ -453,7 +453,7 @@ internal sealed class D3D12RenderingEngine : ID3D12RenderingEngine
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogCritical(ex, "Error disposing Rendering Engine!");
+                    _logger.LogErrorDisposingRenderingEngine(ex);
                 }
                 finally
                 {
@@ -464,7 +464,7 @@ internal sealed class D3D12RenderingEngine : ID3D12RenderingEngine
 
             _disposedValue = true;
 
-            _logger.LogInformation("Destroyed engine!");
+            _logger.LogDestroyedEngine();
         }
     }
 

--- a/src/Demo.Engine.Platform.DirectX12/DebugLayerLogger.cs
+++ b/src/Demo.Engine.Platform.DirectX12/DebugLayerLogger.cs
@@ -2,6 +2,7 @@
 // Distributed under MIT license. See LICENSE file in the root for more information.
 
 using Demo.Engine.Core.Interfaces;
+using Demo.Tools.Common.Logging;
 using Microsoft.Extensions.Logging;
 using Vortice.Direct3D12;
 using Vortice.Direct3D12.Debug;
@@ -164,7 +165,7 @@ internal sealed class DebugLayerLogger
         {
             if (disposing)
             {
-                _logger.LogTrace("Disposing Debug Layer");
+                using var _ = _logger.LogScopeDisposal();
                 _dxgiInfoQueue?.SetBreakOnSeverity(
                     _dxgiGuid,
                     InfoQueueMessageSeverity.Corruption,
@@ -195,8 +196,6 @@ internal sealed class DebugLayerLogger
 
                 _d3d12Debug?.Dispose();
                 _dxgiDebug?.Dispose();
-
-                _logger.LogTrace("Disposed Debug Layer");
             }
 
             // TODO: free unmanaged resources (unmanaged objects) and override finalizer

--- a/src/Demo.Engine.Platform.DirectX12/LoggingExtensions.cs
+++ b/src/Demo.Engine.Platform.DirectX12/LoggingExtensions.cs
@@ -14,13 +14,23 @@ internal static partial class LoggingExtensions
 {
     private const string CREATED_DEVICE_SUPPORTING_FEATURE_LEVEL = "Created device supporting {FeatureLevel}";
     private const string DEBUG_LAYER_MESSAGE = "[{@category}:{@id}] {@description}";
+
     private const string DISPOSING_RENDERING_SURFACE = "Disposing Rendering Surface {SurfaceId}";
     private const string DISPOSED_RENDERING_SURFACE = "Disposed Rendering Surface {SurfaceId}";
     private const string DISPOSING_RTV = "Disposing RTV {RtvId}";
     private const string DISPOSED_RTV = "Disposed RTV {RtvId}";
+
+    private const string FAILED_TO_CREATE_DESCRIPTOR_HEAPS = "Failed to create descriptor heaps: {ErrorMessage}";
+    private const string ERROR_DISPOSING_RENDERING_ENGINE = "Error disposing Rendering Engine!";
+    private const string DESTROYED_ENGINE = "Destroyed engine!";
+
     private const string ATTEMPTING_SHADER_COMPILATION = "Attempting {ShaderFilePath} shader compliation";
-    private const string COMPILING_SHADER = "Compiling {sthaderStage} {shaderFilePath} with {shaderProfile}";
+    private const string COMPILING_SHADER = "Compiling {ShaderStage} {ShaderFilePath} with {ShaderProfile}";
     private const string FATAL_ERROR_WHEN_COMPILING = "Fatal error when compiling {ShaderFilePath}!";
+
+    private const string LOG_INVALID_SRV_DESCRIPTOR = "Invalid SRV descriptor!";
+    private const string NOT_ENOUGH_DATA_TO_READ_32BIT_INT = "Not enough data to read 32-bit integer!";
+    private const string UNEXPECTED_END_OF_STREAM = "Unexpected end of stream!";
 
     [LoggerMessage(
         Level = LogLevel.Debug,
@@ -78,6 +88,26 @@ internal static partial class LoggingExtensions
         int rtvId);
 
     [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = FAILED_TO_CREATE_DESCRIPTOR_HEAPS)]
+    internal static partial void LogFailedToCreateDescriptorHeaps(
+        this ILogger<D3D12RenderingEngine> logger,
+        string errorMessage);
+
+    [LoggerMessage(
+        Level = LogLevel.Critical,
+        Message = ERROR_DISPOSING_RENDERING_ENGINE)]
+    internal static partial void LogErrorDisposingRenderingEngine(
+        this ILogger<D3D12RenderingEngine> logger,
+        Exception ex);
+
+    [LoggerMessage(
+        Level = LogLevel.Trace,
+        Message = DESTROYED_ENGINE)]
+    internal static partial void LogDestroyedEngine(
+        this ILogger<D3D12RenderingEngine> logger);
+
+    [LoggerMessage(
         Level = LogLevel.Information,
         Message = ATTEMPTING_SHADER_COMPILATION)]
     internal static partial void LogCompilingShaderFile(
@@ -89,7 +119,7 @@ internal static partial class LoggingExtensions
         Message = COMPILING_SHADER)]
     internal static partial void LogCompilingShaderFile(
         this ILogger<ShaderCompilerOld> logger,
-        ShaderStage sthaderStage,
+        ShaderStage shaderStage,
         string shaderFilePath,
         string shaderProfile);
 
@@ -100,4 +130,22 @@ internal static partial class LoggingExtensions
         this ILogger<ShaderCompiler> logger,
         Exception exception,
         string shaderFilePath);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = LOG_INVALID_SRV_DESCRIPTOR)]
+    internal static partial void LogInvalidSrvDescriptor(
+        this ILogger<Texture> logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = NOT_ENOUGH_DATA_TO_READ_32BIT_INT)]
+    internal static partial void LogNotEnoughDataToRead32BitInteger(
+        this ILogger<EngineShaderManager> logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = UNEXPECTED_END_OF_STREAM)]
+    internal static partial void LogUnexpectedEndOfStream(
+        this ILogger<EngineShaderManager> logger);
 }

--- a/src/Demo.Engine.Platform.DirectX12/RenderingResources/Texture.cs
+++ b/src/Demo.Engine.Platform.DirectX12/RenderingResources/Texture.cs
@@ -35,7 +35,7 @@ internal sealed class Texture
         SRV = _renderingEngine.SRVHeapAllocator.Allocate();
         if (!SRV.IsValid)
         {
-            _logger.LogError("Invalid SRV descriptor!");
+            _logger.LogInvalidSrvDescriptor();
             throw new InvalidOperationException("Invalid SRV descriptor!");
         }
 

--- a/src/Demo.Engine.Platform.DirectX12/Shaders/EngineShaderManager.cs
+++ b/src/Demo.Engine.Platform.DirectX12/Shaders/EngineShaderManager.cs
@@ -170,7 +170,7 @@ internal sealed class EngineShaderManager(
 
         if (buffer.Length < sizeof(int))
         {
-            _logger.LogError("Not enough data to read 32-bit integer!");
+            _logger.LogNotEnoughDataToRead32BitInteger();
             throw new InvalidOperationException(
                 "Not enough data to read 32-bit integer!");
         }
@@ -199,7 +199,7 @@ internal sealed class EngineShaderManager(
             if (buffer.IsEmpty
                 && result.IsCompleted)
             {
-                _logger.LogError("Unexpected end of stream!");
+                _logger.LogUnexpectedEndOfStream();
                 throw new InvalidOperationException("Unexpected end of stream!");
             }
 

--- a/src/Demo.Engine.Platform.Windows/LoggingExtensions.cs
+++ b/src/Demo.Engine.Platform.Windows/LoggingExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright © Michał Dembski and contributors.
+// Distributed under MIT license. See LICENSE file in the root for more information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Demo.Engine.Platform.Windows;
+
+internal static partial class LoggingExtensions
+{
+    private const string ERROR_IN_MAIN_LOOP_PROCESSING_WINDOWS_MESSAGES = "An error occured in main loop while processing windows messages. Error: {ErrorCode}";
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = ERROR_IN_MAIN_LOOP_PROCESSING_WINDOWS_MESSAGES,
+        SkipEnabledCheck = true)]
+    private static partial void LogErroInMainLoopProcessingWindowsMessages(
+        this ILogger<WindowsMessagesHandler> logger,
+        int errorCode);
+
+    internal static void LogErroInMainLoopProcessingWindowsMessages(
+        this ILogger<WindowsMessagesHandler> logger,
+        Func<int> errorCodeAction)
+    {
+        if (logger.IsEnabled(LogLevel.Error))
+        {
+            logger.LogErroInMainLoopProcessingWindowsMessages(
+                errorCodeAction());
+        }
+    }
+}

--- a/src/Demo.Engine.Platform.Windows/WindowsMessagesHandler.cs
+++ b/src/Demo.Engine.Platform.Windows/WindowsMessagesHandler.cs
@@ -31,9 +31,8 @@ public class WindowsMessagesHandler : IOSMessageHandler
 
                     if ((int)getMessageW == -1)
                     {
-                        _logger.LogError(
-                            "An error occured in main loop while processing windows messages. Error: {errorCode}",
-                            Marshal.GetLastWin32Error());
+                        _logger.LogErroInMainLoopProcessingWindowsMessages(
+                            Marshal.GetLastWin32Error);
 
                         return false;
                     }

--- a/src/Demo.Tools.Common/Logging/LoggingExtensions.cs
+++ b/src/Demo.Tools.Common/Logging/LoggingExtensions.cs
@@ -19,30 +19,61 @@ public static partial class LoggingExtensions
     /// <returns></returns>
     public static LoggingContext<T> LogScopeInitialization<T>(
         this ILogger<T> logger)
-        => new(logger);
+        => new(logger, nameof(Operation.Initialization));
+
+    /// <summary>
+    /// Logs information {ClassName} disposal {state} with state: "started" when context is
+    /// created and "completed" when context is disposed.
+    /// <para/>
+    /// Can be used with using statement to log start and completion of class disposal
+    /// within the using scope
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="logger"></param>
+    /// <returns></returns>
+    public static LoggingContext<T> LogScopeDisposal<T>(
+        this ILogger<T> logger)
+        => new(logger, nameof(Operation.Disposal));
 
     [LoggerMessage(
         Level = LogLevel.Trace,
-        Message = "{ClassName} initialization {State}")]
-    internal static partial void LogClassInitializationState(
+        Message = "{ClassName} {Operation} {State}")]
+    private static partial void LogClassOperationState(
         this ILogger logger,
         string className,
+        string operation,
         string state);
-}
 
-public readonly ref struct LoggingContext<T>
-    : IDisposable
-{
-    private readonly ILogger<T> _logger;
-    private readonly string _className;
-
-    public LoggingContext(ILogger<T> logger)
+    public readonly ref struct LoggingContext<T>
+        : IDisposable
     {
-        _logger = logger;
-        _className = typeof(T).Name;
-        _logger.LogClassInitializationState(_className, state: "started");
+        private readonly ILogger<T> _logger;
+        private readonly string _className;
+        private readonly string _operation;
+
+        public LoggingContext(ILogger<T> logger,
+            string operation,
+            string? className = null)
+        {
+            _logger = logger;
+            _operation = operation;
+            _className = className ?? typeof(T).Name;
+            _logger.LogClassOperationState(_className, operation: _operation, state: nameof(State.Started));
+        }
+
+        public void Dispose()
+            => _logger.LogClassOperationState(_className, operation: _operation, state: nameof(State.Completed));
     }
 
-    public void Dispose()
-        => _logger.LogClassInitializationState(_className, state: "completed");
+    private enum State
+    {
+        Started,
+        Completed,
+    }
+
+    private enum Operation
+    {
+        Initialization,
+        Disposal,
+    }
 }


### PR DESCRIPTION
Migrated previously missed log invocations to source generated logging. Fixed some logging parameters not being PascalCase. Added 2 more diagnostics:
- [CA2254: Template should be a static expression](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2254)
- [CA1727: Use PascalCase for named placeholders](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1727)

fixes #500 