### PR TITLE
Change GITHUB_TOKEN to AUTOMERGE_PAT for merging

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,4 +21,4 @@ jobs:
         gh pr merge --auto --squash "$PR_URL"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.AUTOMERGE_PAT }}


### PR DESCRIPTION
A workflow cannot trigger another workflow if it's using GITHUB_TOKEN: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow